### PR TITLE
fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ const ButtonRoot = styled(TouchableOpacity, {
   // variants
   variants: {
     coloScheme: {
-      positive: {
+      primary: {
         backgroundColor: "green",
       },
       negative: {
@@ -61,7 +61,7 @@ const ButtonRoot = styled(TouchableOpacity, {
 
 const Button = (props) => {
   return (
-    <ButtonRoot colorScheme={"positive"} onPress={props.onPress}>
+    <ButtonRoot colorScheme={"primary"} onPress={props.onPress}>
       {props.children}
     </ButtonRoot>
   );

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ const Button = (props) => {
 };
 ```
 
-### Compund Variants
+### Compound Variants
 
 When needing to set styles for a variant based on a combination of other variants, you can create a rule for compound variants using the + sign.
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ const ButtonRoot = styled(TouchableOpacity, {
   // variants
   variants: {
     coloScheme: {
-      primary: {
-        positive: "green",
+      positive: {
+        backgroundColor: "green",
       },
       negative: {
         backgroundColor: "red",

--- a/packages/babel-plugin/src/index.js
+++ b/packages/babel-plugin/src/index.js
@@ -40,7 +40,7 @@ export default function babelPluginWithStyles({ types }) {
           const styles = styledObjectNode;
 
           // generate compound map
-          const compoundVars = getCompundVariantsMap(compoundVariants);
+          const compoundVars = getCompoundVariantsMap(compoundVariants);
           const variantKeys = getNodeKeys(variants);
 
           // keep other styledObject properties
@@ -169,7 +169,7 @@ function extractProperty(objectExpressionNode, propertyName) {
 }
 
 // Generates a map with compound keys, which will be used to apply those styles when the tree is traversed.
-function getCompundVariantsMap(compoundVariants) {
+function getCompoundVariantsMap(compoundVariants) {
   if (!compoundVariants) {
     return [];
   }

--- a/packages/react/src/core/runtime.ts
+++ b/packages/react/src/core/runtime.ts
@@ -17,7 +17,7 @@ type VariantNode = {
 };
 
 // Generates a map with compound keys, which will be used to apply those styles when the tree is traversed.
-function getCompundVariantsMap(compoundVariants: any) {
+function getCompoundVariantsMap(compoundVariants: any) {
   if (!compoundVariants) {
     return [];
   }
@@ -99,7 +99,7 @@ function variantsTreeTraversal(styledObject: StyledObject<any, any, any>): Recor
     return { default: styles };
   }
 
-  const compoundVars = getCompundVariantsMap(compoundVariants);
+  const compoundVars = getCompoundVariantsMap(compoundVariants);
 
   return variantsNodeTraversal({
     compoundVars,


### PR DESCRIPTION
## Description

Fixed some typos.

## Proposed Changes

- Fixed typo in README.md in usage section, the style property was incorrect.
- Update typo 'Compund' to 'Compound' through out the project.

## Package Updates

[Indicate which packages in the monorepo need to be updated after merging this pull request for the next release.]

- [ ] @fast-styles/babel-plugin
- [ ] @fast-styles/react
- [ ] @fast-styles documentation

