### PR TITLE
Add children type to ModeProvider

### DIFF
--- a/packages/react/src/mode/index.tsx
+++ b/packages/react/src/mode/index.tsx
@@ -28,7 +28,7 @@ const useMode = () => {
  * @param {Object} props - The component props.
  * @returns {JSX.Element} The wrapped component tree with access to the mode context.
  */
-const ModeProvider: React.FC = ({ children }) => {
+const ModeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [mode, setMode] = useState<Mode>('light');
 
   return <ModeContext.Provider value={{ mode, setMode }}>{children}</ModeContext.Provider>;


### PR DESCRIPTION
## Description
Using ModeProvider with typescript thriows an error

```
Type '{ children: Element; }' has no properties in common with type 'IntrinsicAttributes'.ts(2559)
⚠ Error (TS2559)  | 
Type 
 has no properties in common with type 
 .
(alias) const ModeProvider: React.FC<{}>
import ModeProvider
Provider component to wrap the components that need access to the mode context.

@param props — The component props.

@returns — The wrapped component tree with access to the mode context.
```

## Proposed Changes

Added a type for the children of ModeProvider

## Package Updates


- [ ] @fast-styles/babel-plugin
- [x ] @fast-styles/react
- [ ] @fast-styles documentation

## References
None
